### PR TITLE
fix: 更正TuniaoUI文档链接地址

### DIFF
--- a/docs/base/ui/ui.md
+++ b/docs/base/ui/ui.md
@@ -19,7 +19,7 @@
 - uv-ui (uveiw 系) - [文档地址](https://www.uvui.cn/)
 - uview-plus (uveiw 系) - [文档地址](https://uiadmin.net/uview-plus/)
 - Wot Design Uni (wot 系) - [文档地址](https://wot-design-uni.netlify.app/)
-- TuniaoUI （图鸟系） - [文档地址](https://vue3.tuniaokj.com/zh-CN/)
+- TuniaoUI （图鸟系） - [文档地址](https://vue3.tuniaokj.com/)
 - Sard uniapp （Sard系） - [文档地址](https://sard.wzt.zone/sard-uniapp-docs/)
 
 还有 2 个 UI 框架也很优秀，大部分组件开源免费，还有一部分组件是收费的，有需要的可以看看。


### PR DESCRIPTION
将TuniaoUI文档链接从带有/zh-CN路径的URL更改为不带此路径的URL。原链接
(https://vue3.tuniaokj.com/zh-CN/)已失效并返回404错误，新链接(https:// vue3.tuniaokj.com/)可以正常访问。此更新确保用户可以通过文档中的链接正确
访问TuniaoUI的官方文档，提高了文档的可用性和准确性。